### PR TITLE
fedora 43 -> fedora 44

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,13 +4,13 @@
 ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME:-kinoite}"
 ARG SOURCE_IMAGE="${BASE_IMAGE_NAME}-main"
 # Static value enables Renovate to detect and update the base image
-ARG BASE_IMAGE="ghcr.io/ublue-os/kinoite-main:43"
+ARG BASE_IMAGE="ghcr.io/ublue-os/kinoite-main:44"
 ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
 # SHA pinning enables Renovate to automatically update dependencies
 # See: https://docs.renovatebot.com/docker/#digest-pinning
 
 # Base Image @ ublue-os/main
-ARG BASE_IMAGE_SHA="sha256:7c0eee6c27ed148e5c83e6a5a0416f29974ce2d02b9f147f98b65c1894162ce3"
+ARG BASE_IMAGE_SHA="sha256:e2f7358fc5302e1a0f6a9ef3286201fba69ce75face0ad3cb1942793088f793f"
 
 # Brew Image
 ARG BREW_IMAGE_SHA="sha256:615439b696bc0d9756850506f803e77a88cae032af1f933b876dddc2bd62d1f7"

--- a/build/03-third-party-packages.sh
+++ b/build/03-third-party-packages.sh
@@ -49,7 +49,7 @@ echo "::group:: Install COPR Packages"
 
 copr_install_isolated "scottames/ghostty" "ghostty"
 
-copr_install_isolated "quadratech188/vicinae" "vicinae"
+# copr_install_isolated "quadratech188/vicinae" "vicinae"
 
 copr_install_isolated "ublue-os/packages" \
     "krunner-bazaar"

--- a/build/03-third-party-packages.sh
+++ b/build/03-third-party-packages.sh
@@ -56,17 +56,17 @@ copr_install_isolated "ublue-os/packages" \
 
 echo "::endgroup::"
 
-echo "::group:: Install Flatpak Preinstall Support"
+# echo "::group:: Install Flatpak Preinstall Support"
 
-# TODO: Remove this section when flatpak preinstall is available in Fedora stable
-dnf5 -y copr enable ublue-os/flatpak-test
-dnf5 -y copr disable ublue-os/flatpak-test
-dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak flatpak
-dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-libs flatpak-libs
-dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-session-helper flatpak-session-helper
-dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test install flatpak-debuginfo flatpak-libs-debuginfo flatpak-session-helper-debuginfo
+# # TODO: Remove this section when flatpak preinstall is available in Fedora stable
+# dnf5 -y copr enable ublue-os/flatpak-test
+# dnf5 -y copr disable ublue-os/flatpak-test
+# dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak flatpak
+# dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-libs flatpak-libs
+# dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-session-helper flatpak-session-helper
+# dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test install flatpak-debuginfo flatpak-libs-debuginfo flatpak-session-helper-debuginfo
 
-echo "::endgroup::"
+# echo "::endgroup::"
 
 if [[ ${IMAGE_FLAVOR} =~ gaming ]]; then
     echo "::group:: Add Gaming Packages from COPR"

--- a/build/03-third-party-packages.sh
+++ b/build/03-third-party-packages.sh
@@ -49,7 +49,7 @@ echo "::group:: Install COPR Packages"
 
 copr_install_isolated "scottames/ghostty" "ghostty"
 
-copr_install_isolated "scottames/vicinae" "vicinae"
+copr_install_isolated "quadratech188/vicinae" "vicinae"
 
 copr_install_isolated "ublue-os/packages" \
     "krunner-bazaar"

--- a/build/04-workarounds.sh
+++ b/build/04-workarounds.sh
@@ -27,8 +27,8 @@ sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/com.mit
 cp /usr/share/applications/com.mitchellh.ghostty.desktop /usr/share/kglobalaccel/
 
 # Configure Vicinae launcher for KDE (Super+Space to toggle)
-sed -i 's@\[Desktop Action toggle\]@\[Desktop Action toggle\]\nX-KDE-Shortcuts=Meta+Space@g' /usr/share/applications/vicinae.desktop
-cp /usr/share/applications/vicinae.desktop /usr/share/kglobalaccel/
+# sed -i 's@\[Desktop Action toggle\]@\[Desktop Action toggle\]\nX-KDE-Shortcuts=Meta+Space@g' /usr/share/applications/vicinae.desktop
+# cp /usr/share/applications/vicinae.desktop /usr/share/kglobalaccel/
 
 # # Force Ptyxis version opened via dbus (e.g., keyboard shortcut) to use the proper shim
 # # https://github.com/ublue-os/bazzite/pull/3620

--- a/services.json
+++ b/services.json
@@ -10,13 +10,17 @@
                 "disable": []
             },
             "user": {
-                "enable": ["bazaar.service", "vicinae.service"],
+                "enable": [
+                    "bazaar.service"
+                ],
                 "disable": []
             }
         },
         "dx": {
             "system": {
-                "enable": ["docker.socket"],
+                "enable": [
+                    "docker.socket"
+                ],
                 "disable": []
             },
             "user": {


### PR DESCRIPTION
Notes:

- No suitable Vicinae COPR worked and I haven't really been using it, so I removed it for now.
- Flatpak preinstall override should no longer be necessary since Fedora ships with it in 44.